### PR TITLE
'NelsonMartell\Extensions\String' class compatible with PHP7

### DIFF
--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -20,7 +20,7 @@
 
 namespace NelsonMartell\Collections {
 
-    use NelsonMartell\Extensions\String as Text;
+    use NelsonMartell\Extensions\Text;
     use NelsonMartell\Object;
 
     /**

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -20,7 +20,7 @@
 
 namespace NelsonMartell\Collections {
 
-    use NelsonMartell\Extensions\String;
+    use NelsonMartell\Extensions\String as Text;
     use NelsonMartell\Object;
 
     /**
@@ -171,7 +171,7 @@ namespace NelsonMartell\Collections {
          * @param string $format String format (optional). By default, `r`.
          *
          * @return string
-         * @see    String::format
+         * @see    Text::format
          * */
         public function toString($format = 'r')
         {
@@ -211,7 +211,7 @@ namespace NelsonMartell\Collections {
             ];
 
 
-            $s = String::Format($str, $placeHoldersValues);
+            $s = Text::format($str, $placeHoldersValues);
 
             return $s;
         }

--- a/src/Extensions/String.php
+++ b/src/Extensions/String.php
@@ -18,7 +18,7 @@
  * */
 namespace NelsonMartell\Extensions;
 
-use Cake\Utility\Text;
+use Cake\Utility\Text as TextBase;
 use \InvalidArgumentException;
 
 /**
@@ -28,7 +28,7 @@ use \InvalidArgumentException;
  * @see \Cake\Utility\Text::insert
  * @see http://book.cakephp.org/3.0/en/core-libraries/text.html
  * */
-class String extends Text
+class String extends TextBase
 {
 
     /**

--- a/src/Extensions/Text.php
+++ b/src/Extensions/Text.php
@@ -13,7 +13,7 @@
  *
  * @copyright 2015-2016 Nelson Martell
  * @link      http://nelson6e65.github.io/php_nml/
- * @since     v0.4.1
+ * @since     v0.7.0
  * @license   http://www.opensource.org/licenses/mit-license.php The MIT License (MIT)
  * */
 namespace NelsonMartell\Extensions;
@@ -27,10 +27,8 @@ use \InvalidArgumentException;
  *
  * @see \Cake\Utility\Text::insert
  * @see http://book.cakephp.org/3.0/en/core-libraries/text.html
- * @deprecated since v0.7.0 (due to PHP 7 conflicts), will be removed in v0.8.0.
- *   Use `\NelsonMartell\Extensions\Text` instead.
  * */
-class String extends TextBase
+class Text extends TextBase
 {
 
     /**

--- a/src/PropertiesHandler.php
+++ b/src/PropertiesHandler.php
@@ -19,7 +19,7 @@
 
 namespace NelsonMartell {
 
-    use NelsonMartell\Extensions\String as Text;
+    use NelsonMartell\Extensions\Text;
     use \BadMethodCallException;
     use \InvalidArgumentException;
 

--- a/src/PropertiesHandler.php
+++ b/src/PropertiesHandler.php
@@ -19,7 +19,7 @@
 
 namespace NelsonMartell {
 
-    use NelsonMartell\Extensions\String;
+    use NelsonMartell\Extensions\String as Text;
     use \BadMethodCallException;
     use \InvalidArgumentException;
 
@@ -136,7 +136,7 @@ namespace NelsonMartell {
         private function ensurePropertyExists($name)
         {
             try {
-                $pName = String::ensureIsValidVarName($name);
+                $pName = Text::ensureIsValidVarName($name);
             } catch (InvalidArgumentException $error) {
                 $msg = nml_msg('Property name is not valid.');
                 throw new BadMethodCallException($msg, 10, $error);
@@ -168,7 +168,7 @@ namespace NelsonMartell {
         private function ensureMethodExists($name)
         {
             try {
-                $mName = String::ensureIsValidVarName($name);
+                $mName = Text::ensureIsValidVarName($name);
             } catch (InvalidArgumentException $error) {
                 $msg = nml_msg('Method name is not valid.');
                 throw new BadMethodCallException($msg, 20, $error);
@@ -264,7 +264,7 @@ namespace NelsonMartell {
             $prefix = 'set';
             if (property_exists($this, 'setterPrefix')) {
                 try {
-                    $prefix = String::ensureIsString($this->setterPrefix);
+                    $prefix = Text::ensureIsString($this->setterPrefix);
                 } catch (InvalidArgumentException $e) {
                     $msg = nml_msg(
                         'Custom property setter prefix is defined, but its value should be an "string"; "{0}" given.',
@@ -294,7 +294,7 @@ namespace NelsonMartell {
             $prefix = 'get';
             if (property_exists($this, 'getterPrefix')) {
                 try {
-                    $prefix = String::ensureIsString($this->getterPrefix);
+                    $prefix = Text::ensureIsString($this->getterPrefix);
                 } catch (InvalidArgumentException $e) {
                     $msg = nml_msg(
                         'Custom property getter prefix is defined, but its value should be an "string"; "{0}" given.',

--- a/src/deprecated_functions.php
+++ b/src/deprecated_functions.php
@@ -17,7 +17,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.php The MIT License (MIT)
  * */
 
-use NelsonMartell\Extensions\String as Text;
+use NelsonMartell\Extensions\Text;
 use NelsonMartell\Type;
 
 /**

--- a/src/deprecated_functions.php
+++ b/src/deprecated_functions.php
@@ -17,12 +17,12 @@
  * @license   http://www.opensource.org/licenses/mit-license.php The MIT License (MIT)
  * */
 
-use NelsonMartell\Extensions\String;
+use NelsonMartell\Extensions\String as Text;
 use NelsonMartell\Type;
 
 /**
  * Busca un mensaje único traducido en el dominio 'nml'.
- * El mensaje puede contener cadenas de formato.
+ * El mensaje puede contener cadenas de formato.``
  *
  * @param string      $message Mensaje con formato que se va a buscar.
  * @param array|mixed $args    Un objeto, una lista de objetos o múltiples
@@ -41,7 +41,7 @@ function nml_msg($message, $args = null)
         $args = array_slice(func_get_args(), 1);
     }
 
-    return String::format($translated, $args);
+    return Text::format($translated, $args);
 }
 
 
@@ -70,7 +70,7 @@ function nml_nmsg($singular, $plural, $n, $args = null)
         $args = array_slice(func_get_args(), 3);
     }
 
-    return String::format($translated, $args);
+    return Text::format($translated, $args);
 }
 
 if (!function_exists('typeof')) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,7 +19,7 @@
 
 namespace NelsonMartell;
 
-use NelsonMartell\Extensions\String;
+use NelsonMartell\Extensions\String as Text;
 
 /**
  * Busca un mensaje único traducido en el dominio 'nml'.
@@ -41,7 +41,7 @@ function msg($message, $args = null)
         $args = \array_slice(func_get_args(), 1);
     }
 
-    return String::format($translated, $args);
+    return Text::format($translated, $args);
 }
 
 
@@ -69,7 +69,7 @@ function nmsg($singular, $plural, $n, $args = null)
         $args = \array_slice(func_get_args(), 3);
     }
 
-    return String::format($translated, $args);
+    return Text::format($translated, $args);
 }
 
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -19,7 +19,7 @@
 
 namespace NelsonMartell;
 
-use NelsonMartell\Extensions\String as Text;
+use NelsonMartell\Extensions\Text;
 
 /**
  * Busca un mensaje único traducido en el dominio 'nml'.


### PR DESCRIPTION
PHP7 collision issue:
Cannot use `NelsonMartell\Extensions\String` as `String` because 'String' is a special class name.

If problems in any application, just set alias for class:
```php
use NelsonMartell\Extensions\String as Text;
```

>TODO: Deprecate this class and replace it with `Text`.